### PR TITLE
feat: register Mauro_CategoryTracking module and configure basic setup(#1)

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Mauro_CategoryTracking" setup_version="1.0.0">
+        <sequence>
+            <module name="Magento_Catalog"/>
+        </sequence>
+    </module>
+</config>

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Mauro_CategoryTracking',
+    __DIR__
+);


### PR DESCRIPTION
- Adds the basic registration and configuration for the `Mauro_CategoryTracking` module.
- Ensures the module is recognized by Magento 2 without any errors.
